### PR TITLE
Target Spawn Logic

### DIFF
--- a/Assets/Prefabs/TargetWithLabel.prefab
+++ b/Assets/Prefabs/TargetWithLabel.prefab
@@ -126,8 +126,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 4
-  m_fontSizeBase: 4
+  m_fontSize: 2
+  m_fontSizeBase: 2
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18

--- a/Assets/Prefabs/TargetWithLabel.prefab
+++ b/Assets/Prefabs/TargetWithLabel.prefab
@@ -34,8 +34,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.06, y: 0.42}
-  m_SizeDelta: {x: 20, y: 5}
+  m_AnchoredPosition: {x: 0, y: -0.75}
+  m_SizeDelta: {x: 1, y: 0.5}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!23 &9182891537587204441
 MeshRenderer:
@@ -196,7 +196,7 @@ Transform:
   m_GameObject: {fileID: 9069779975850492026}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.7469803, y: -1.7026746, z: -0.007228421}
+  m_LocalPosition: {x: 0, y: 0, z: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -214,15 +214,15 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4709680825464143610, guid: 0d5b511235b786c4bbdfe17600f801cd, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4709680825464143610, guid: 0d5b511235b786c4bbdfe17600f801cd, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.25
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4709680825464143610, guid: 0d5b511235b786c4bbdfe17600f801cd, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.007228421
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4709680825464143610, guid: 0d5b511235b786c4bbdfe17600f801cd, type: 3}
       propertyPath: m_LocalRotation.w

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -1,0 +1,269 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &82630035
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 82630036}
+  - component: {fileID: 82630037}
+  m_Layer: 0
+  m_Name: TargetManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &82630036
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 82630035}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &82630037
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 82630035}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 72c54eb5ad0944f44985f3a401ae9bcf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  target: {fileID: 9069779975850492026, guid: 0f4561498d80b914d9fb686f36e540e2, type: 3}
+  numTargets: 100
+  targetScale: 1
+--- !u!1 &2013827781
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2013827784}
+  - component: {fileID: 2013827783}
+  - component: {fileID: 2013827782}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &2013827782
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2013827781}
+  m_Enabled: 1
+--- !u!20 &2013827783
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2013827781}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &2013827784
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2013827781}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 2013827784}
+  - {fileID: 82630036}

--- a/Assets/Scripts/TargetManager.cs
+++ b/Assets/Scripts/TargetManager.cs
@@ -6,8 +6,8 @@ using UnityEngine;
 public class TargetManager : MonoBehaviour
 {
     [SerializeField] private GameObject target;
-    [SerializeField] [Range(1,100)] private int numTargets;
-    [SerializeField] [Range(1,10)] private float targetScale;
+    [SerializeField] [Range(1,200)] private int numTargets;
+    [SerializeField] [Range(0.1f,10)] private float targetScale;
     
     private List<Target> targetList = new();
     private List<Vector2> targetPositions = new();

--- a/Assets/Scripts/TargetManager.cs
+++ b/Assets/Scripts/TargetManager.cs
@@ -7,13 +7,13 @@ public class TargetManager : MonoBehaviour
 {
     [SerializeField] private GameObject target;
     [SerializeField] [Range(1,100)] private int numTargets;
-
+    [SerializeField] [Range(1,10)] private float targetScale;
+    
     private List<Target> targetList = new();
     private List<Vector2> targetPositions = new();
     private Camera mainCamera;
     private float worldWidth, worldHeight;
     private float targetWidth, targetHeight;
-    
     private const float TargetSpacing = 1.5f;
     private string[] appNames = { "TaskFlow Pro", "NoteHaven", "DocuMaster", "QuickNote", "PlanEase", "Taskify", "PaperTrail", "MemoGraph", "TimeLine", "FocusBox", "SprintTrack", "ZenDoc", "ProWriter", "StudySpace", "QuickOffice", "PrintMaster", "WorkBench", "FileForge", "ClearWrite", "ProDesk", "SnapCraft", "PixelCraftr", "IdeaScribe", "SketchBlend", "ColorPulse", "DesignForge", "Artify", "VibeDraw", "VectorPrime", "PhotoLab", "SoundCraftr", "ClipStudio", "MindWave", "Animatrix", "LightBurst", "FlowSketch", "MotionDeck", "CanvasNova", "ImageForge", "ShapeWave", "CodeForge", "DevPad", "GitHub Pro", "ScriptRunner", "BuildSphere", "CompilerX", "CodeFlow", "DebugMaster", "DevSync", "TerminalX", "CloudIDE", "SnapBuild", "CodeSmith", "DevDesk", "AppSync", "SourceCraft", "DevSnap", "ProjectPad", "VersionVault", "SyncWrite", "MovieBox", "Streamify", "RadioFusion", "MusicMate", "GameSparks", "PlayBox", "CineMate", "SoundStorm", "MovieVault", "AudioFlow", "MediaCraft", "SongLab", "StreamX", "ShowLoop", "FlickPlay", "SoundBurst", "GameForge", "ChillBox", "MusicWave", "TuneMaster", "FileMender", "DiskCleaner", "BackupHub", "CleanSweep" };
 
@@ -31,6 +31,7 @@ public class TargetManager : MonoBehaviour
     private void GetTargetSize()
     {
         var sampleTarget = Instantiate(target, new Vector3(0,0,0), Quaternion.identity);
+        sampleTarget.transform.localScale = Vector3.one * targetScale;
         sampleTarget.name = "SampleTarget";
         sampleTarget.transform.parent = mainCamera.transform;
         Canvas.ForceUpdateCanvases();
@@ -45,8 +46,8 @@ public class TargetManager : MonoBehaviour
     private void GenerateTargetPositions()
     {
         targetPositions.Clear();
-        var columns = (int) (worldWidth / TargetSpacing);
-        var rows = (int) (worldHeight / TargetSpacing);
+        var columns = (int) (worldWidth / (TargetSpacing * targetScale));
+        var rows = (int) (worldHeight / (TargetSpacing * targetScale));
         for (var y = (int) -Math.Floor(rows/2.0f); y < (int) Math.Floor(rows/2.0f); y++)
         {
             for (var x = -columns/2; x < columns/2; x++)
@@ -85,10 +86,10 @@ public class TargetManager : MonoBehaviour
             x,
             y,
             1f
-        ) * TargetSpacing;
+        ) * (TargetSpacing * targetScale);
                     
         var targetObject = Instantiate(target, pos, Quaternion.identity, transform);
-        targetObject.transform.localScale = Vector3.one;
+        targetObject.transform.localScale = Vector3.one * targetScale;
         targetObject.transform.parent = mainCamera.transform;
         targetObject.name = "Target" + appIndex;
                 

--- a/Assets/Scripts/TargetManager.cs
+++ b/Assets/Scripts/TargetManager.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
+using Random = System.Random;
 
 public class TargetManager : MonoBehaviour
 {
@@ -18,66 +20,72 @@ public class TargetManager : MonoBehaviour
     private void Start()
     {
         mainCamera = Camera.main;
-        screenCentre = new Vector2(Screen.width/2, Screen.height / 2);
+        screenCentre = new Vector2(Screen.width/2.0f, Screen.height/2.0f);
         SpawnTargets();
 
     }
-
+    
     private void SpawnTargets()
     {
-        List<Vector3> points = GenerateRandomPoints();
-        for (int i = 0; i < numTargets; i++)
-        {
-            GameObject targetObject = Instantiate(target, points[i], Quaternion.identity, transform);
-            targetObject.transform.localScale = Vector3.one;
+        //List<Vector3> points = GenerateTargetGrid(numTargets);
+        float targetWidth = 37.0f, targetHeight = 50.0f;
+        float padding = 1.5f;
+        int gridColumns = (int) (Screen.width / (targetWidth * padding));
+        int gridRows = (int) (Screen.height / (targetHeight + 10.0f));
 
-            //TextMeshPro label = targetObject.GetComponent<TextMeshPro>();
-            //label.text = appNames[i % appNames.Length];
+        Debug.Log(gridColumns);
+        Debug.Log(gridRows);
+
+        var rand = new Random();
+        for (float y = -gridRows/2.0f; y < gridRows/2.0f; y++)
+        {
+            for (float x = -gridColumns/2.0f; x < gridColumns/2.0f; x++)
+            {
+                var targetObject = Instantiate(target, new Vector3(x + 0.625f, y, 1f) * padding, Quaternion.identity, transform);
+                targetObject.transform.localScale = Vector3.one;
+                targetObject.transform.parent = mainCamera.transform;
+                
+                var label = targetObject.GetComponentInChildren<TextMeshPro>();
+                label.text = appNames[rand.Next(appNames.Length)];
+            }
         }
     }
 
-    List<Vector3> GenerateRandomPoints()
+    List<Vector3> GenerateTargetGrid(int targetsPerCorner = 1)
     {
         List<Vector3> pointList = new();
-        for (int i = 0; i < numTargets; i++)
-        {
-            float randomX = Random.Range(0, Screen.width);
-            float randomY = Random.Range(0, Screen.height);
-            float z = 10f;
-            Vector3 randomScreenPoint = new(randomX, randomY, z);
-            Vector3 randomWorldPoint = mainCamera.ScreenToWorldPoint(randomScreenPoint);
-            pointList.Add(randomWorldPoint);
-        }
-        return pointList;
-    }
+        var sprite = target.GetComponentInChildren<SpriteRenderer>();
+        float targetBoundsX = sprite.sprite.bounds.size.x / sprite.sprite.pixelsPerUnit,
+            targetBoundsY = sprite.sprite.bounds.size.y / sprite.sprite.pixelsPerUnit;
 
-    private List<int> GenerateCornerCounts()
-    {
-        List<int> counts = new List<int> { 1, 1, 1, 1 }; // Minimum 1 icon in each corner
-        int remainingTargets = numTargets - 4; // Subtract the 1 in each corner
-
-        // Distribute remaining icons randomly, up to 5 per corner
-        for (int i = 0; i < 4; i++)
+        for (var quarter = 1; quarter <= 4; quarter++)
         {
-            int additionalTargets = Random.Range(0, Mathf.Min(remainingTargets, 4)); // Max 5 per corner
-            counts[i] += additionalTargets;
-            remainingTargets -= additionalTargets;
-        }
+            float xStart = quarter % 2 == 0
+                ? Screen.width / 2.0f
+                : 0;
+            xStart += targetBoundsX;
+            float yStart = quarter > 2
+                ? Screen.height / 2.0f
+                : Screen.height;
+            yStart += targetBoundsY;
 
-        // If any icons are left distribute them among corners
-        while (remainingTargets > 0)
-        {
-            for (int i = 0; i < 4 && remainingTargets > 0; i++)
+            var targetCount = 0;
+            for (var x = 1; x <= 3; x++)
             {
-                if (counts[i] < 5)
+                for (var y = 1; y <= 3; y++)
                 {
-                    counts[i]++;
-                    remainingTargets--;
+                    if (targetCount > targetsPerCorner) continue;
+                    pointList.Add(new Vector3(
+                        xStart + (x * targetBoundsX),
+                        yStart - (y * targetBoundsY),
+                        1f
+                    ));
+                    targetCount++;
                 }
             }
         }
 
-        return counts;
+        return pointList;
     }
 
 }

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,6 +6,6 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
-    path: Assets/Scenes/SampleScene.unity
-    guid: 2cda990e2423bbf4892e6590ba056729
+    path: Assets/Scenes/MainScene.unity
+    guid: 1685e6bb0f48b2b458e7b20ef65ec20f
   m_configObjects: {}


### PR DESCRIPTION
Closes #1 
Implemented the logic for target spawning in a desktop-like grid

- [x] Targets spawn in a desktop-like grid 
- [x] Number of targets can be specified (**most distant targets are prioritized in positions**)
- [x] Adequate spacing between targets is ensured
- [x] Target size can be changed, grid adjusted accordingly
- [x] Grid adjusts based on the viewport size

When it comes to the study ramifications of this configuration:
- **Width** can be treated as an interval (established distance between measures)
- **Amplitude** can be treated as an interval/ratio (not sure about ratio) as it will have to be dynamically calculated depending on the target (also however we handle the pie menu distance?) 