### PR TITLE
Amplitude works (mostly)

### DIFF
--- a/Assets/Scripts/PointCursor.cs
+++ b/Assets/Scripts/PointCursor.cs
@@ -20,15 +20,22 @@ public class PointCursor : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
+
         //Get Mouse Position on screen, and get the corresponding position in a Vector3 World Co-Ordinate
         Vector3 mousePosition = Input.mousePosition;
 
         //Change the z position so that cursor does not get occluded by the camera
-        mousePosition.z += 9f;
+        mousePosition.z += 1f;
         mousePosition.x = Mathf.Clamp(mousePosition.x, 0f, Screen.width);
         mousePosition.y = Mathf.Clamp(mousePosition.y, 0f, Screen.height);
 
         transform.position = mainCam.ScreenToWorldPoint(mousePosition);
+
+        // Vector3 screenCentre = new Vector3(Screen.width / 2, Screen.height / 2, 1f);
+        // Vector3 worldCentre = mainCam.ScreenToWorldPoint(screenCentre);
+
+        // float distanceFromCenter = Vector3.Distance(worldCentre, transform.position);
+        // Debug.Log("Amplitude: " + distanceFromCenter);
 
         // Casting a ray straight down, below the cursor
         Collider2D detectedCollider = Physics2D.OverlapPoint(transform.position);

--- a/Assets/Scripts/StudyManager.cs
+++ b/Assets/Scripts/StudyManager.cs
@@ -99,7 +99,7 @@ public struct TrialConditions       // These are the factors that affect how the
 {
     public float amplitude;                   // Distance from the center
     public GroupingType groupingType;         // Random zones or predefined "ordered" zones
-    public float TargetToHitboxRatio;                 // Ratio of effective width to target size for dynamic hitbox resizing and/or increasing space between icons
+    public float targetToHitboxRatio;                 // Ratio of effective width to target size for dynamic hitbox resizing and/or increasing space between icons
 }
 
 public enum CursorType
@@ -178,7 +178,7 @@ public class StudySettings
                     {
                         amplitude = amp,
                         groupingType = GroupingType.Random,     
-                        TargetToHitboxRatio = targetRatio,
+                        targetToHitboxRatio = targetRatio,
                     });
                 }
                 
@@ -196,7 +196,7 @@ public class StudySettings
                     {
                         amplitude = amp,
                         groupingType = GroupingType.Ordered,
-                        TargetToHitboxRatio = targetRatio,
+                        targetToHitboxRatio = targetRatio,
                     });
                 }
 

--- a/Assets/Scripts/StudyManager.cs
+++ b/Assets/Scripts/StudyManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using Random = UnityEngine.Random;
 
@@ -19,9 +20,9 @@ public class StudyManager : MonoBehaviour
     private GameObject centerTargetObject;
     private CursorType originalCursor;
 
-    // private StudySettings studySettings;
-    // List<TrialConditions> trialSequence;
-    // private int currentTrialIndex = 0;
+    private StudySettings studySettings;
+    private List<TrialConditions> trialSequence;
+    private int currentTrialIndex;
     private float movementStartTime = 0;
     private float totalMovementTime = 0;
     private int trialMisclicks = 0;
@@ -40,9 +41,14 @@ public class StudyManager : MonoBehaviour
 
     private void Start()
     {
+        originalCursor = CursorType.PointCursor;
+        studySettings = StudySettings.GetStudySettings(originalCursor, 1);      // See the StudySettings class to make changes to A,W,etc
+        trialSequence = StudySettings.CreateSequenceOfTrials(studySettings);
+        Debug.Log("Number of trials: " + trialSequence.Count);
+        currentTrialIndex = 0;
+
         numTotalTargets = targetManager.GetNumTotalTargets();
         targetManager.SpawnStartTarget();
-        Debug.Log(targetManager.GetNumTotalTargets());
     }
 
     private void Update()
@@ -50,12 +56,13 @@ public class StudyManager : MonoBehaviour
         targetObjectsOnScreen = targetManager.GetAllTargets();
         numTargetsOnScreen = targetObjectsOnScreen.Length;
         
-        // To start with, there is always one target. If there are 0 on the screen, that means start target was clicked.
+        // To start with, there is always one Start target. If there are 0 on the screen, that means start target was clicked.
         if (numTargetsOnScreen == 0)
         {
             ResetTrialMisclicks();
             movementStartTime = Time.time;
-            targetManager.SpawnTargets(); // maybe to implement factors, we would pass in a parameter of type TrialConditions here
+            targetManager.SpawnTargets(trialSequence[currentTrialIndex]); 
+            currentTrialIndex++;
         } 
         // If there are n - 1 targets on screen (assuming only goal target is clickable), then spawn the start target again.
         else if (numTargetsOnScreen == numTotalTargets - 1)
@@ -64,7 +71,7 @@ public class StudyManager : MonoBehaviour
             targetManager.DestroyAllTargets();
 
             Debug.Log("Movement Time: " + totalMovementTime + "ms");
-            Debug.Log("Total errors: " + (trialMisclicks-1));
+            Debug.Log("Total errors: " + (trialMisclicks-1));       // Subtract 1 because currently even clicking the goal target increments misclicks.
 
             targetManager.SpawnStartTarget();
         }
@@ -117,7 +124,7 @@ public enum GroupingType
 public class StudySettings
 {
     public List<float> amplitudes;
-    public List<float> TargetToHitboxRatios; // denotes the constant scaling factor based on which we increase both the gap between icons and the hitbox of each icon
+    public List<float> targetToHitboxRatios; // denotes the constant scaling factor based on which we increase both the gap between icons and the hitbox of each icon
     // public List<bool> recent; idk if we're going with this for factor
     public List<GroupingType> groupingTypes;
     public CursorType cursorType;
@@ -126,7 +133,7 @@ public class StudySettings
     public StudySettings(List<float> amplitudes, List<float> targetToHitboxRatios, List<GroupingType> groupingTypes, CursorType cursorType, int repetitions)
     {
         this.amplitudes = amplitudes;
-        this.TargetToHitboxRatios = targetToHitboxRatios;
+        this.targetToHitboxRatios = targetToHitboxRatios;
         this.groupingTypes = groupingTypes;
         this.cursorType = cursorType;
         this.repetitions = repetitions;
@@ -135,50 +142,70 @@ public class StudySettings
     public StudySettings(List<float> amplitudes, List<float> targetToHitboxRatios, List<GroupingType> groupingTypes, CursorType cursorType)
     {
         this.amplitudes = amplitudes;
-        this.TargetToHitboxRatios = targetToHitboxRatios;
+        this.targetToHitboxRatios = targetToHitboxRatios;
         this.groupingTypes = groupingTypes;
         this.cursorType = cursorType;
         this.repetitions = 1;
     }
 
     // Returns the settings we choose for the study. 
-    public StudySettings GetStudySettings(CursorType chosenCursor, int repetitions)
+    public static StudySettings GetStudySettings(CursorType chosenCursor, int repetitions)
     {
         return new StudySettings(
-            new List<float> { 20f, 50f, 80f },                                          // Amplitudes
-            new List<float> { 1f, 1.5f, 2f },                                           // EW to W ratios
+            new List<float> { 8f, 12f, 16f },                                           // Amplitudes
+            new List<float> { 1f, 1.5f, 2f },                                           // Target width to Hitbox ratios
             new List<GroupingType>() { GroupingType.Random, GroupingType.Ordered },     // A trial can either have random groups or ordered groups 
-            chosenCursor,                                                                // cursorType
+            chosenCursor,                                                               // cursorType
             repetitions
         );
     }
 
-    // Returns a randomized list of trial conditions that the TargetManager should use to spawn targets
-    private List<TrialConditions> CreateSequenceOfTrials()
+    // Given study settings, returns a randomized list of trial conditions that the TargetManager should use to spawn targets
+    public static List<TrialConditions> CreateSequenceOfTrials(StudySettings studySettings)
     {
-        List<TrialConditions> trialSequence = new List<TrialConditions>();
-        StudySettings studySettings = GetStudySettings(CursorType.PointCursor, repetitions = 1);
+        // Could refactor this into 4 nested loops to avoid repetition but it would look ugly and be less readable.
+        // One sequence for each type of grouping: Random and Ordered
+        List<TrialConditions> randomTrialSequence = new List<TrialConditions>();
+        List<TrialConditions> orderedTrialSequence = new List<TrialConditions>();
 
         for (int i = 0; i < studySettings.repetitions; i++)
         {
-            foreach (float targetRatio in studySettings.TargetToHitboxRatios)
+            foreach (float targetRatio in studySettings.targetToHitboxRatios)
             {
-                foreach (GroupingType grouping in studySettings.groupingTypes)
+                foreach (float amp in studySettings.amplitudes)
                 {
-                    foreach (float amp in studySettings.amplitudes)
+                    randomTrialSequence.Add(new TrialConditions
                     {
-                        trialSequence.Add(new TrialConditions
-                        {
-                            amplitude = amp,
-                            groupingType = grouping,
-                            TargetToHitboxRatio = targetRatio,
-                        });
-                    }
+                        amplitude = amp,
+                        groupingType = GroupingType.Random,     
+                        TargetToHitboxRatio = targetRatio,
+                    });
                 }
+                
             }
         }
-        trialSequence = YatesShuffle<TrialConditions>(trialSequence);
-        return trialSequence;
+        randomTrialSequence = YatesShuffle<TrialConditions>(randomTrialSequence);
+
+        for (int i = 0; i < studySettings.repetitions; i++)
+        {
+            foreach (float targetRatio in studySettings.targetToHitboxRatios)
+            {
+                foreach (float amp in studySettings.amplitudes)
+                {
+                    orderedTrialSequence.Add(new TrialConditions
+                    {
+                        amplitude = amp,
+                        groupingType = GroupingType.Ordered,
+                        TargetToHitboxRatio = targetRatio,
+                    });
+                }
+
+            }
+        }
+        orderedTrialSequence = YatesShuffle<TrialConditions>(orderedTrialSequence);
+        
+        randomTrialSequence.AddRange(orderedTrialSequence);
+        return randomTrialSequence;
     }
 
     private static List<T> YatesShuffle<T>(List<T> list)

--- a/Assets/Scripts/Target.cs
+++ b/Assets/Scripts/Target.cs
@@ -21,7 +21,7 @@ public class Target : MonoBehaviour
     public void SetGoalTarget()
     {
         isGoal = true;
-        Debug.Log("Set to Goal!");
+        // Debug.Log("Set to Goal!");
         ChangeColor(Color.red);
     }
 

--- a/Assets/Scripts/TargetManager.cs
+++ b/Assets/Scripts/TargetManager.cs
@@ -109,6 +109,8 @@ public class TargetManager : MonoBehaviour
         int appIndex = 0;
         int targetCount = 0;
 
+        float width = trialConditions.TargetToHitboxRatio;
+
         var rand = new Random();
 
         // Start at quadrant 4 and go backwards to 1. Makes it easier to add remaining targets to the top left (since on a desktop the top left is often more dense).
@@ -161,6 +163,10 @@ public class TargetManager : MonoBehaviour
                 appIndex++;
             }
         }
+
+        // After spawning targets according to Grouping and EW, pick Goal Target according to A:
+        float amplitude = trialConditions.amplitude;
+        PickTarget(amplitude);
     }
     
     private void SpawnTarget(float x, float y, int appIndex)
@@ -201,6 +207,12 @@ public class TargetManager : MonoBehaviour
         var label = startTargetObject.GetComponentInChildren<TextMeshPro>();
         label.text = "Start!";
     }
+
+    private void PickTarget(float amplitude)
+    {
+
+    }
+
     public GameObject[] GetAllTargets()
     {
         return GameObject.FindGameObjectsWithTag("Target");

--- a/Assets/Scripts/TargetManager.cs
+++ b/Assets/Scripts/TargetManager.cs
@@ -104,12 +104,12 @@ public class TargetManager : MonoBehaviour
         });
     }
     
-    public void SpawnTargets()
+    public void SpawnTargets(TrialConditions trialConditions)
     {
         int appIndex = 0;
         int targetCount = 0;
 
-        // var rand = new Random();
+        var rand = new Random();
 
         // Start at quadrant 4 and go backwards to 1. Makes it easier to add remaining targets to the top left (since on a desktop the top left is often more dense).
         for (int quadrant = 4; quadrant >= 1; quadrant--)
@@ -126,12 +126,13 @@ public class TargetManager : MonoBehaviour
                 Vector3 position = quadrantPositions[0];
                 quadrantPositions.RemoveAt(0);
 
-                // if (rand.Next(0, 4) == 2)
-                // {
-                //     q.RemoveAt(0);
-                //     q.Add(position);
-                //     continue;
-                // }
+                if (rand.Next(0, 4) == 2)
+                {
+                    quadrantPositions.RemoveAt(0);
+                    quadrantPositions.Add(position);
+                    continue;
+                }
+
                 SpawnTarget(position.x, position.y, appIndex);
                 targetCountPerQuadrant++; targetCount++;
                 appIndex++;         
@@ -149,12 +150,12 @@ public class TargetManager : MonoBehaviour
                 Vector3 position = quadrantPositions[0];
                 quadrantPositions.RemoveAt(0);
 
-                // if (rand.Next(0, 4) == 2)
-                // {
-                //     q.RemoveAt(0);
-                //     q.Add(position);
-                //     continue;
-                // }
+                if (rand.Next(0, 4) == 2)
+                {
+                    quadrantPositions.RemoveAt(0);
+                    quadrantPositions.Add(position);
+                    continue;
+                }
                 SpawnTarget(position.x, position.y, appIndex);
                 targetCount++;
                 appIndex++;


### PR DESCRIPTION
## Main changes 

Goal selection is now somewhat controlled. Sometimes it repeats the same goal when the width is different but that should be fixed when we add the other factors for target spawning. 

Starts work on #10, should be fairly straightforward to implement the other factors using the logic from this PR.

## Main additions

TargetManager's SpawnTargets() function now accepts a TrialConditions object as an argument, which contains A,W,and grouping type (for now) which are the factors that affect target spawning. *After* targets are spawned (currently still not using any factors), we use TrialConditions.amplitude to pick a goal target that is closest to `amplitude` units away from the center of the screen.

